### PR TITLE
fix(bootstrap): 使用gorm建表，指定默认charset为utf8mb4.

### DIFF
--- a/bootstrap/db.go
+++ b/bootstrap/db.go
@@ -103,7 +103,7 @@ func getGormLogWriter() logger.Writer {
 
 // 数据库表初始化
 func initMySqlTables(db *gorm.DB) {
-    err := db.AutoMigrate(
+    err := db.Set("gorm:table_options", "ENGINE=InnoDB CHARSET=utf8mb4").AutoMigrate(
         models.User{},
         models.Media{},
     )


### PR DESCRIPTION
创建表时追加 “ENGINE=InnoDB CHARSET=utf8mb4” 到 SQL 语句中

测试环境：MariaDB:10.9.3
直接使用gorm.AutoMigrate时，创建的表默认为 `DEFAULT CHARSET=latin1` 
[参考gorm文档《迁移》](https://v1.gorm.io/zh_CN/docs/migration.html)  
